### PR TITLE
Start ElasticSearch on reboot.

### DIFF
--- a/storage-bootstrap.sh
+++ b/storage-bootstrap.sh
@@ -93,6 +93,10 @@ else
   service elasticsearch restart
 fi
 
+# Make sure ES starts when the VM reboots
+sudo update-rc.d elasticsearch defaults 95 10
+sudo /etc/init.d/elasticsearch start
+
 apt-get autoremove -y
 
 


### PR DESCRIPTION
ElasticSearch starts when provisioned but doesn't start on reboot.
